### PR TITLE
Fix toUnit for decimal point with preceding 0's

### DIFF
--- a/substratebalancegraph.js
+++ b/substratebalancegraph.js
@@ -36,7 +36,6 @@ function updateUrl(startBlock, endBlock) {
 function toUnit(balance, decimals) {
     base = new BN(10).pow(new BN(decimals));
     dm = new BN(balance).divmod(base);
-    dm.mod.toString().padStart(chainDecimal, '0')
     return parseFloat(dm.div.toString() + "." + dm.mod.toString().padStart(chainDecimal, '0'))
 }
 

--- a/substratebalancegraph.js
+++ b/substratebalancegraph.js
@@ -36,7 +36,8 @@ function updateUrl(startBlock, endBlock) {
 function toUnit(balance, decimals) {
     base = new BN(10).pow(new BN(decimals));
     dm = new BN(balance).divmod(base);
-    return parseFloat(dm.div.toString() + "." + dm.mod.toString())
+    dm.mod.toString().padStart(chainDecimal, '0')
+    return parseFloat(dm.div.toString() + "." + dm.mod.toString().padStart(chainDecimal, '0'))
 }
 
 // Given an address and a range of blocks, query the Substrate blockchain for the balance across the range


### PR DESCRIPTION
This should fix the cases where the value after decimal point has preceding zero's.
e.g. 
balance = 1002
decimals = 3
currently toUnit(balance, decimals) calculates
dm.div = 1002/(10^3) = 1
dm.mod = 1002%(10^3) = 2
,and returns 1.2 while should return 1.002

the dm.mod is padded with 0's up to chainDecimal number of digits to generate the correct fixed point value.
